### PR TITLE
added config option in proxies.conf to record-route on all requests

### DIFF
--- a/lib/oversip/proxies_config.rb
+++ b/lib/oversip/proxies_config.rb
@@ -11,6 +11,7 @@ module OverSIP
 
     @proxy_configuration = {
       :do_record_routing          => true,
+      :record_route_all           => false,
       :use_dns                    => true,
       :use_dns_cache              => true,
       :dns_cache_time             => 300,
@@ -30,6 +31,7 @@ module OverSIP
 
     PROXY_CONFIG_VALIDATIONS = {
       :do_record_routing          => :boolean,
+      :record_route_all           => :boolean,
       :use_dns                    => :boolean, 
       :use_dns_cache              => :boolean,
       :dns_cache_time             => [ :fixnum, [ :greater_equal_than, 300 ] ],
@@ -176,6 +178,9 @@ module OverSIP
 
         # Add a hash for the blacklist.
         @proxies[proxy][:blacklist] = {}
+        
+        # Only allow record routing for all requsts if record routing is enabled
+        @proxies[proxy][:record_route_all] = false  unless @proxies[proxy][:do_record_routing]
       end
     end
 

--- a/lib/oversip/sip/proxy.rb
+++ b/lib/oversip/sip/proxy.rb
@@ -187,7 +187,7 @@ module OverSIP::SIP
       add_rr_path = false
 
       # NOTE: As per RFC 6665 the proxy MUST add Record-Route to in-dialog NOTIFY's.
-      if (@request.initial? and @request.record_routing_aware?) or @request.sip_method == :NOTIFY
+      if (@request.initial? and @request.record_routing_aware?) or @request.sip_method == :NOTIFY or @conf[:record_route_all]
         do_record_routing = @conf[:do_record_routing]
 
         # Request has no previous RR/Path and current proxy performs record-routing.


### PR DESCRIPTION
Some times we need to know if an in dialog request or response from an in dialog request came from oversip.  We look at the Record-Route: header to determine if the previous hop was an oversip proxy.

Having the ability to turn on record routing for all requests is a useful option for us, and I think for others as well.