### PR TITLE
Always include flowtokens in record-route headers for outbound requests.

### DIFF
--- a/lib/oversip/sip/proxy.rb
+++ b/lib/oversip/sip/proxy.rb
@@ -270,7 +270,7 @@ module OverSIP::SIP
             @request.in_rr = :rr
             # The request comes via UDP or via a connection made by the client.
             if @request.connection.class.outbound_listener?
-              @request.insert_header "Record-Route", @request.connection.class.record_route
+              @request.insert_header "Record-Route", "<sip:" << @request.connection_outbound_flow_token << @request.connection.class.outbound_record_route_fragment
             # The request comes via a TCP/TLS connection made by OverSIP.
             else
               @request.insert_header "Record-Route", @request.connection.record_route


### PR DESCRIPTION
This change makes it so record route header content is consistent, and will contain flow tokens for any outbound request, even if it is not an initial request.

We have proxies that will look at record-route headers and recognize oversip flow tokens from oversip, then use them to rewrite the contact for GRUU purposes.  When oversip record-routes on a sequential request such as a REFER and does not include the flow token, it can break break the routing of requests targeted at the oversip client.

Making the record-route header content consistent for initial and sequential requests from an outbound client resolves this issue, as well as making sure that UAS who either throw away, or update the route set continue to route requests properly.

