### PR TITLE
[Typo] Fixes typos in ruby_c_util.h

### DIFF
--- a/ext/common/ruby_c_util.h
+++ b/ext/common/ruby_c_util.h
@@ -15,7 +15,7 @@
 
 
 /*
- * my_rb_str_hex_unescape: Unexcapes hexadecimal encoded symbols (%NN).
+ * my_rb_str_hex_unescape: Unescapes hexadecimal encoded symbols (%NN).
  */
 static VALUE my_rb_str_hex_unescape(const char *str, size_t len)
 {


### PR DESCRIPTION
Fixes typos in ruby_c_util.h.