### PR TITLE
OverSIP::SIP::Connection: no more send_error_handling=

### DIFF
--- a/lib/oversip/sip/listeners/connection.rb
+++ b/lib/oversip/sip/listeners/connection.rb
@@ -32,9 +32,6 @@ module OverSIP::SIP
       @state = :init
       @cvars = {}
 
-      # Set the socket sending error handling to report the error:
-      # :ERRORHANDLING_KILL, :ERRORHANDLING_IGNORE, :ERRORHANDLING_REPORT
-      self.send_error_handling = :ERRORHANDLING_REPORT
     end
 
     def receive_senderror error, data


### PR DESCRIPTION
This was an EventMachine-LE-ism.